### PR TITLE
Add total task request report endpoint to dashboard

### DIFF
--- a/BE/GRRWS.Application/Implement/Service/HOTDashboardService.cs
+++ b/BE/GRRWS.Application/Implement/Service/HOTDashboardService.cs
@@ -71,5 +71,9 @@ namespace GRRWS.Application.Implement.Service
             var taskCompletionCount = await _unitOfWork.HOTDashboardRepository.GetTaskCompletionCountByWeekAndMonthAsync();
             return Result.SuccessWithObject(taskCompletionCount);
         }
+        public async Task<Result> GetTotalTaskRequestReportAsync() { 
+            var totalTaskRequestReport = await _unitOfWork.HOTDashboardRepository.GetTotalTaskRequestReportAsync();
+            return Result.SuccessWithObject(totalTaskRequestReport);
+        }
     }
 }

--- a/BE/GRRWS.Application/Interface/IService/IHOTDashboardService.cs
+++ b/BE/GRRWS.Application/Interface/IService/IHOTDashboardService.cs
@@ -11,6 +11,7 @@ namespace GRRWS.Application.Interface.IService
         Task<Result> GetReportStatisticsAsync();
         Task<Result> GetTaskStatisticsAsync();
         Task<Result> GetDeviceStatisticsAsync();
+        Task<Result> GetTotalTaskRequestReportAsync();
         Task<Result> GetTotalUserByRoleAsync();
         Task<Result> GetTaskCompletionCountByWeekAndMonthAsync();
     }

--- a/BE/GRRWS.Host/Controllers/DashboardController.cs
+++ b/BE/GRRWS.Host/Controllers/DashboardController.cs
@@ -55,6 +55,14 @@ namespace GRRWS.Host.Controllers
                 ? ResultExtensions.ToSuccessDetails(result, "Get task statistics successfully!")
                 : ResultExtensions.ToProblemDetails(result);
         }
+        [HttpGet("get-total-task-request-report")]
+        public async Task<IResult> GetTotalTaskRequestReportAsync()
+        {
+            var result = await _hotDashboardService.GetTotalTaskRequestReportAsync();
+            return result.IsSuccess
+                ? ResultExtensions.ToSuccessDetails(result, "Get task statistics successfully!")
+                : ResultExtensions.ToProblemDetails(result);
+        }
         [HttpGet("get-total-user-by-role")]
         public async Task<IResult> GetTotalUserByRoleAsync()
         {

--- a/BE/GRRWS.Infrastructure/Implement/Repositories/HOTDashboardRepository.cs
+++ b/BE/GRRWS.Infrastructure/Implement/Repositories/HOTDashboardRepository.cs
@@ -206,7 +206,7 @@ namespace GRRWS.Infrastructure.Implement.Repositories
         }
         public async Task<TaskStatisticsDTO> GetTaskStatisticsAsync()
         {
-            var totalTasks = await _context.Tasks.Where(t => !t.IsDeleted && t.TaskType == TaskType.Warranty && t.TaskType == TaskType.Repair && t.TaskType == TaskType.Replacement).CountAsync();
+            var totalTasks = await _context.Tasks.Where(t => !t.IsDeleted && (t.TaskType == TaskType.Warranty || t.TaskType == TaskType.Repair || t.TaskType == TaskType.Replacement)).CountAsync();
 
             var totalWarrantyTasks = await _context.Tasks.Where(t => !t.IsDeleted && t.TaskType == TaskType.Warranty).CountAsync();
 

--- a/BE/GRRWS.Infrastructure/Interfaces/IRepositories/IHOTDashboardRepository.cs
+++ b/BE/GRRWS.Infrastructure/Interfaces/IRepositories/IHOTDashboardRepository.cs
@@ -17,6 +17,7 @@ namespace GRRWS.Infrastructure.Interfaces.IRepositories
         Task<ReportStatisticsDTO> GetReportStatisticsAsync();
         Task<TaskStatisticsDTO> GetTaskStatisticsAsync();
         Task<DeviceStatisticsDTO> GetDeviceStatisticsAsync();
+        Task<TotalTaskRequestReportDTO> GetTotalTaskRequestReportAsync();
         Task<TotalUserByRoleDTO> GetTotalUserByRoleAsync();
         Task<TaskByWeekAndMonthDTO> GetTaskCompletionCountByWeekAndMonthAsync();
     }


### PR DESCRIPTION
Introduces a new service and API endpoint to retrieve the total task request report in the dashboard. Updates service, repository, and controller layers to support this feature. Also fixes a logical error in the task statistics query.